### PR TITLE
[DEP0047] DeprecationWarning Fix

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -5,7 +5,7 @@ var values = require('./values')
 
 var appleEpoch = Date.UTC(1904, 0, 1)
 var appleDate = function (value) {
-  if (util.isDate(value) === false) {
+  if (value instanceof Date === false) {
     // value = new Date(value);
     throw new TypeError('Not a date: ' + value)
   }


### PR DESCRIPTION
Fix [DEP0047] DeprecationWarning: The `util.isDate` API is deprecated.  Please use `arg instanceof Date` instead.